### PR TITLE
Added -f parameter name.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Tslint(Linter):
     """Provides an interface to tslint."""
 
     syntax = 'typescript'
-    cmd = ('tslint', '@')
+    cmd = ('tslint', '-f', '@')
     regex = (
         r'^.+?\[(?P<line>\d+), (?P<col>\d+)\]: '
         r'(?P<message>.+)'


### PR DESCRIPTION
Newer versions of tslint require the -f parameter to accept the file being linted. 