### PR TITLE
Override configuration filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ For general information on how SublimeLinter works with settings, please see [Se
 
 You can configure `tslint` options in the way you would from the command line, with `tslint.json` files. For more information, see the [tslint docs](https://github.com/palantir/tslint). The linter plugin does this by searching for a `tslint.json` file itself, just as `tslint` does from the command line. You may provide a custom config file by setting the linter’s `"args"` setting to `["--config", "/path/to/file"]`. On Windows, be sure to double the backslashes in the path, for example `["--config", "C:\\Users\\Aparajita\\tslint.json"]`.
 
+Alternatively, you can set the `config_filename` option to just the name of the configuration file in order to avoid defining absolute paths.
+
+```json
+    "linters": {
+        "tslint": {
+            "@disable": false,
+            "args": [],
+            "excludes": [
+                "**/node_modules/**"
+            ],
+            "config_filename": "tsconfig.json"
+        }
+    }
+```
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/linter.py
+++ b/linter.py
@@ -10,15 +10,16 @@
 
 """This module exports the Tslint plugin class."""
 
-from SublimeLinter.lint import Linter, util
+from SublimeLinter.lint import NodeLinter, util
 
 
-class Tslint(Linter):
+class Tslint(NodeLinter):
 
     """Provides an interface to tslint."""
 
     syntax = ('typescript', 'typescriptreact')
     cmd = ('tslint', '@')
+    npm_name = 'tslint'
     regex = (
         r'^.+?\[(?P<line>\d+), (?P<col>\d+)\]: '
         r'(?P<message>.+)'
@@ -29,3 +30,16 @@ class Tslint(Linter):
     version_args = '--version'
     version_requirement = '>= 0.4.0'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
+
+    def build_args(self, settings=None):
+        """Override build_args to allow setting a custom config filename."""
+        backup = self.config_file
+        if 'config_filename' in settings and self.filename:
+            self.config_file = self.config_file[:1] + (settings['config_filename'],) + self.config_file[2:]
+
+        out = super().build_args(settings)
+
+        # Reset the value of config_file so that this can apply per-project.
+        self.config_file = backup
+
+        return out


### PR DESCRIPTION
This PR,

- Allows configuring config filename through `config_filename` option.
- Makes linter extend `NodeLinter` instead of `Linter`.
- Extends doc to comment on the feature.

I know that a custom config file can be provided using `"args"` but that is kind of cumbersome to handle as you:

- Need to provide absolute full paths.
- Can't reuse setting for different projects (unless you place your `.json` file in some common folder, which is unlikely).

Also, made the linter extend `NodeLinter` which, according to official docs adds:

```python
    - Support for finding local binaries in a project's
      ./node_modules/.bin/ folder. You need to override npm_name
      variable to use this linter.
    - comment_re is defined correctly for JavaScript. If your
      linter can be found in the node_modules folder, but lints
      a different language, you should override this with the
      correct regular expression for the comments in the files
      being linted.
```