### PR TITLE
Feature/tslint project

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Alternatively, you can set the `config_filename` option to just the name of the 
     }
 ```
 
+Also, remember to set your project `tsconfig.json` accordingly, so that it includes paths used by SublimeLinter *working copies*. For example:
+
+```json
+    "include": [
+        "/var/folders/**/*.tsx",
+        "/var/folders/**/*.ts",
+        "./src/**/*.tsx",
+        "./src/**/*.ts"
+    ],
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/linter.py
+++ b/linter.py
@@ -30,7 +30,7 @@ class Tslint(NodeLinter):
     # tempfile_suffix = {'typescript': 'ts', 'typescriptreact': 'tsx'}
     tempfile_suffix = '-'
     version_args = '--version'
-    version_requirement = '>= 3.14.0'
+    version_requirement = '>= 5.8.0'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
 
     def build_args(self, settings=None):
@@ -43,7 +43,7 @@ class Tslint(NodeLinter):
 
         projectPath = self.__findTSConfigPath()
         if projectPath is not None:
-            out.extend(['--project', projectPath, '--type-check'])
+            out.extend(['--project', projectPath])
 
         # Reset the value of config_file so that this can apply per-project.
         self.config_file = backup


### PR DESCRIPTION
This is discussed in issue #15, this pull request just adapts to use `tslint --project project/tsconfig.json` with SublimeLinter-contrib-tslint.

This is required generally by latest tslint 5.x together with TypeScript 2.x.

There are generally drawbacks in TypeScript & tslint design:
- `/var/folders/...` paths need to be manually added to all projects `tsconfig.json` project files, in order to use SublimeLinter in general
- `tslint` doesn't use TSCServer, which makes it very slow compared to integration between TypeScript for example with VSCode

Credit from the changes goes mostly to @janslow, this patch is just a small update + added documentation.